### PR TITLE
Fix build with crypton; revive doctests; resolve #2

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -37,4 +37,4 @@ jobs:
     - name: Build
       run: cabal build --enable-tests --enable-benchmarks all
     - name: Run tests
-      run: cabal test test:testsuite
+      run: cabal test all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased 0.12.0
+
+* Pull updates in cryptostore, fixing build with crypton.
+
 # 2021-12-11 0.11.0
 
 * Added support for RSA256 Public Key verification. This in turn means that some 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased 0.12.0
 
 * Pull updates in cryptostore, fixing build with crypton.
+* Stabilize ordering of keys, both in the header and in claims, resolving
+  [#2](https://github.com/puffnfresh/haskell-jwt/issues/2).
+* Fix and reenable doctests.
 
 # 2021-12-11 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Stabilize ordering of keys, both in the header and in claims, resolving
   [#2](https://github.com/puffnfresh/haskell-jwt/issues/2).
 * Fix and reenable doctests.
+* Drop support for aeson < 2.
 
 # 2021-12-11 0.11.0
 

--- a/doctests.hs
+++ b/doctests.hs
@@ -1,4 +1,7 @@
-import Test.DocTest
+import System.Exit (exitWith)
+import System.Process (system)
 
 main :: IO ()
-main = doctest ["-isrc", "src"]
+main = do
+  exitWith =<< system "cabal repl --with-ghc=doctest"
+  -- See README of doctest https://hackage.haskell.org/package/doctest

--- a/jwt.cabal
+++ b/jwt.cabal
@@ -43,7 +43,7 @@ library
                      , memory                   >= 0.8
                      , bytestring               >= 0.10
                      , text                     >= 0.11
-                     , aeson                    >= 0.7
+                     , aeson                    >= 2
                      , containers               >= 0.5
                      , unordered-containers     >= 0.2
                      , scientific               >= 0.2

--- a/jwt.cabal
+++ b/jwt.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                jwt
-version:             0.11.0
+version:             0.12.0
 synopsis:            JSON Web Token (JWT) decoding and encoding
 license:             MIT
 license-file:        LICENSE
@@ -39,7 +39,7 @@ library
   exposed-modules:     Web.JWT
   other-modules:       Data.Text.Extended, Data.ByteString.Extended
   build-depends:       base >= 4.8 && < 5
-                     , cryptostore              >= 0.3.0.1
+                     , cryptostore              >= 0.5.0.0
                      , memory                   >= 0.8
                      , bytestring               >= 0.10
                      , text                     >= 0.11

--- a/jwt.cabal
+++ b/jwt.cabal
@@ -96,7 +96,7 @@ test-suite testsuite
                      , memory
                      , bytestring               >= 0.10
                      , text                     >= 0.11
-                     , aeson
+                     , aeson                    >= 2
                      , scientific               >= 0.2
                      , containers
                      , unordered-containers

--- a/jwt.cabal
+++ b/jwt.cabal
@@ -124,3 +124,4 @@ test-suite doctests
   build-depends:       base < 5 && >= 4.8
                      , jwt
                      , doctest     >= 0.20
+                     , process

--- a/src/Web/JWT.hs
+++ b/src/Web/JWT.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                #-}
 {-# LANGUAGE EmptyDataDecls     #-}
 {-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE GADTs              #-}
@@ -93,6 +92,8 @@ import           Crypto.Store.X509          (readPubKeyFileFromMemory)
 import           Data.ByteArray.Encoding
 import           Data.Aeson                 hiding (decode, encode)
 import qualified Data.Aeson                 as JSON
+import qualified Data.Aeson.Key             as Key
+import qualified Data.Aeson.KeyMap          as KeyMap
 import qualified Data.Map                   as Map
 import           Data.Maybe
 import           Data.Scientific
@@ -102,13 +103,6 @@ import           Data.X509                  (PrivKey (PrivKeyRSA), PubKey (PubKe
 import           Data.X509.Memory           (readKeyFileFromMemory)
 import qualified Network.URI                as URI
 import           Prelude                    hiding (exp)
-
-#if MIN_VERSION_aeson(2,0,0)
-import qualified Data.Aeson.Key             as Key
-import qualified Data.Aeson.KeyMap          as KeyMap
-#else
-import qualified Data.HashMap.Strict        as KeyMap
-#endif
 
 {-# DEPRECATED JWTHeader "Use JOSEHeader instead. JWTHeader will be removed in 1.0" #-}
 type JWTHeader = JOSEHeader
@@ -555,13 +549,7 @@ instance Semigroup.Semigroup ClaimsMap where
     ClaimsMap $ a Semigroup.<> b
 
 fromHashMap :: Object -> ClaimsMap
-fromHashMap = ClaimsMap . Map.fromList . map (first toText) . KeyMap.toList
-  where
-#if MIN_VERSION_aeson(2,0,0)
-    toText = Key.toText
-#else
-    toText = id
-#endif
+fromHashMap = ClaimsMap . Map.fromList . map (first Key.toText) . KeyMap.toList
 
 removeRegisteredClaims :: ClaimsMap -> ClaimsMap
 removeRegisteredClaims (ClaimsMap input) = ClaimsMap $ Map.differenceWithKey (\_ _ _ -> Nothing) input registeredClaims
@@ -577,13 +565,7 @@ instance ToJSON JWTClaimsSet where
                 , fmap ("nbf" .=) nbf
                 , fmap ("iat" .=) iat
                 , fmap ("jti" .=) jti
-            ] ++ map (first fromText) (Map.toList $ unClaimsMap $ removeRegisteredClaims unregisteredClaims)
-      where
-#if MIN_VERSION_aeson(2,0,0)
-        fromText = Key.fromText
-#else
-        fromText = id
-#endif
+            ] ++ map (first Key.fromText) (Map.toList $ unClaimsMap $ removeRegisteredClaims unregisteredClaims)
 
 instance FromJSON JWTClaimsSet where
         parseJSON = withObject "JWTClaimsSet"

--- a/src/Web/JWT.hs
+++ b/src/Web/JWT.hs
@@ -565,7 +565,8 @@ instance ToJSON JWTClaimsSet where
                 , fmap ("nbf" .=) nbf
                 , fmap ("iat" .=) iat
                 , fmap ("jti" .=) jti
-            ] ++ map (first Key.fromText) (Map.toList $ unClaimsMap $ removeRegisteredClaims unregisteredClaims)
+            ] ++ map (first Key.fromText)
+                     (Map.toList $ unClaimsMap $ removeRegisteredClaims unregisteredClaims)
     -- See [NOTE] Encoding VS Value, and json objects keys ordering
     toEncoding JWTClaimsSet{..} = pairs . mconcat $ catMaybes [
                   fmap ("iss" .=) iss

--- a/src/Web/JWT.hs
+++ b/src/Web/JWT.hs
@@ -262,7 +262,7 @@ instance Semigroup.Semigroup JWTClaimsSet where
 --      key = hmacSecret . T.pack $ "secret-key"
 --  in encodeSigned key mempty cs
 --  :}
---  "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwOi8vZXhhbXBsZS5jb20vaXNfcm9vdCI6dHJ1ZSwiaXNzIjoiRm9vIn0.vHQHuG3ujbnBUmEp-fSUtYxk27rLiP2hrNhxpyWhb2E"
+--  "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJGb28iLCJodHRwOi8vZXhhbXBsZS5jb20vaXNfcm9vdCI6dHJ1ZX0.9uim_nuzFyiZ3qqJrzZRieGTOLRNOYlYvmhrqg8KYfQ"
 encodeSigned :: EncodeSigner -> JOSEHeader -> JWTClaimsSet -> T.Text
 encodeSigned signer header' claims' = dotted [header'', claim, signature']
     where claim     = encodeJWT claims'
@@ -286,7 +286,7 @@ encodeSigned signer header' claims' = dotted [header'', claim, signature']
 --            }
 --  in encodeUnsigned cs mempty
 --  :}
---  "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjEzOTQ3MDA5MzQsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlLCJpc3MiOiJGb28ifQ."
+--  "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJGb28iLCJpYXQiOjEzOTQ3MDA5MzQsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ."
 encodeUnsigned :: JWTClaimsSet -> JOSEHeader -> T.Text
 encodeUnsigned claims' header' = dotted [header'', claim, ""]
     where claim     = encodeJWT claims'
@@ -566,6 +566,17 @@ instance ToJSON JWTClaimsSet where
                 , fmap ("iat" .=) iat
                 , fmap ("jti" .=) jti
             ] ++ map (first Key.fromText) (Map.toList $ unClaimsMap $ removeRegisteredClaims unregisteredClaims)
+    -- See [NOTE] Encoding VS Value, and json objects keys ordering
+    toEncoding JWTClaimsSet{..} = pairs . mconcat $ catMaybes [
+                  fmap ("iss" .=) iss
+                , fmap ("sub" .=) sub
+                , either ("aud" .=) ("aud" .=) <$> aud
+                , fmap ("exp" .=) exp
+                , fmap ("nbf" .=) nbf
+                , fmap ("iat" .=) iat
+                , fmap ("jti" .=) jti
+            ] ++ map (uncurry (.=) . first Key.fromText)
+                     (Map.toList $ unClaimsMap $ removeRegisteredClaims unregisteredClaims)
 
 instance FromJSON JWTClaimsSet where
         parseJSON = withObject "JWTClaimsSet"
@@ -597,6 +608,34 @@ instance ToJSON JOSEHeader where
                 , fmap ("alg" .=) alg
                 , fmap ("kid" .=) kid
             ]
+    -- See [NOTE] Encoding VS Value, and json objects keys ordering
+    toEncoding JOSEHeader{..} = pairs . mconcat . catMaybes $ [
+                  fmap ("typ" .=) typ
+                , fmap ("cty" .=) cty
+                , fmap ("alg" .=) alg
+                , fmap ("kid" .=) kid
+            ]
+
+{- [NOTE] Encoding VS Value, and json objects keys ordering
+
+Unlike Encoding, aeson's Value may, and will, reorder keys.
+
+This can cause annoying issues, where the JWT encodings that we produce may "wobble"
+across (non-breaking) updates in dependencies (particularly, in unordered-containers).
+
+One such issue was reported at https://github.com/puffnfresh/haskell-jwt/issues/2 .
+Both encodings are technically correct and valid -- yet, this broke somebody's test
+and ate people's time.
+
+Another occurrence manifested in doctests of this very module. There, it is especially
+vexing, because doctests showcase API usage primarily (and as a bonus, double-duty as tests).
+I.e. doctests are not the place to be explicitly handling multiple valid outputs
+(the in-code "expected value" may validly be this, or that, depending on what exact versions
+of dependencies we're compiling with), all the while exemplifying how to get any JWT output
+in the first place. But, where?
+
+In ToJSON class, there's an optional toEncoding method that can stabilize the ordering.
+-}
 
 instance ToJSON NumericDate where
     toJSON (NumericDate i) = Number $ scientific (fromIntegral i) 0

--- a/tests/src/Web/JWTInteropTests.hs
+++ b/tests/src/Web/JWTInteropTests.hs
@@ -24,6 +24,7 @@ module Web.JWTInteropTests (
 
 import           Prelude hiding (exp)
 import           Control.Lens
+import qualified Data.Aeson.Key as Key
 import           Data.Aeson.Lens
 import           Data.Aeson.Types
 import qualified Data.Map              as Map
@@ -56,7 +57,7 @@ prop_encode_decode_iss = shouldBeMaybeStringOrUri "iss" iss
 
 shouldBeMaybeStringOrUri :: ToJSON a => T.Text -> (a -> Maybe StringOrURI) -> a -> Bool
 shouldBeMaybeStringOrUri key' f claims' = 
-    let json = toJSON claims' ^? key key'
+    let json = toJSON claims' ^? key (Key.fromText key')
     in json == (fmap (String . stringOrURIToText) $ f claims')
 
 prop_encode_decode_aud :: JWTClaimsSet -> Bool


### PR DESCRIPTION
Hi Brian @puffnfresh !

I was looking into what'd be needed to get "the" haskell jwt library 😃 back into Stackage LTS snapshots. Ended up with this maintenance patch series. 👀 Please review.

Apologies for piling up several things together; one thing led to another... The overall PR came out not that large, hoping won't be a big hassle to approve for merging.

On top of individual commit messages, some higher-level bullet points for context:
 * [Stackage][] had dropped `jwt` in [994f351b][] within PR https://github.com/commercialhaskell/stackage/pull/7431 — due to abandonment of x509-* family of packages, which included some of `jwt` dependees. cc @mihaimaruseac.
 * This has been partially addressed in #5 — however, `cryptostore` itself was having issues with `+use_crypton`; it wasn't bulding.
 * And *that* issue, finally, **has been resolved** https://codeberg.org/ocheron/cryptostore/issues/1 just a week ago.
   * cryptostore-0.5.0.0 released, and builds with crypton. 🎉  kudos @marinelli

This means `jwt` is finally in good position to adopt `+use_crypton`, as the blocker hinted at in #8 is now resolved.

I took this deep-dive as opportunity to do a check-up on the doctests as well — which led to reverting 4390e2e13ab16ae6d7421c8c49a399e0db80aa22 and a few other minor changes. In particular, #2 becomes resolved by accident. Doctests do run and pass. ✅ 

One of the minor changes was dropping aeson <2 — its v2 is fairly mature by now, released 5 years ago, and has had good adoption in many packages across the ecosystem. LMK if you'd like to support aeson v1 anyway; I'll try to see what can be done to force CPP + doctests into good neighborship.

[Stackage]: https://www.stackage.org/
[994f351b]: https://github.com/commercialhaskell/stackage/commit/994f351b8d68a80e2fe8d7a63db3b4f319d16e21 

Resolves #2.
Supersedes #3.
Continues #5 and #8.